### PR TITLE
Credentials now unicode exceptions + restructuring. 1.2.4

### DIFF
--- a/lib/core.py
+++ b/lib/core.py
@@ -13,6 +13,12 @@ class Core:
 
     api_translator = None
 
+    class Api:
+        RPC_LITERAL_BRANDED = 'http://paint.pure360.com/paint.pure360.com/ctrlPaintLiteral.wsdl'
+        RPC_LITERAL_UNBRANDED = 'http://emailapi.co.uk/emailapi.co.uk/ctrlPaintLiteral.wsdl'
+        USERNAME = 'userName'
+        PASSWORD = 'password'
+
     class Type:
         ENTITY = 'bus_entity'
         FACADE = 'bus_facade'
@@ -97,8 +103,8 @@ class Core:
         self.api_username = api_username
         self.api_password = api_password
         auth_response = self.make_request(Core.Class.CONTEXT,
-                                          Core.Process.AUTHENTICATE, {'userName': api_username,
-                                                                      'password': api_password})
+                                          Core.Process.AUTHENTICATE, {Core.Api.USERNAME: api_username,
+                                                                      Core.Api.PASSWORD: api_password})
 
         if not auth_response.get('ok'):
             message = ('Failed to authenticate credentials: api_username=%s, api_password=%s, response=%s' %

--- a/lib/translator.py
+++ b/lib/translator.py
@@ -52,9 +52,10 @@ class Translator:
                 setattr(value, 'arr', self.ensuds(dictionary[key]))
             elif isinstance(dictionary[key], str) or isinstance(dictionary[key], unicode):
                 escaped = self.x_encode(dictionary[key], 'xmlcharrefreplace')
-                if isinstance(dictionary[key], unicode) and not key.isdigit() and not (key in self.main.unicode_exceptions):
-                    escaped = base64.b64encode(escaped)
-                    setattr(pair, 'key', getattr(pair, 'key') + '_base64')
+                if isinstance(dictionary[key], unicode) and not key.isdigit() and not (key in self.main.encoding_exceptions):
+                    (key, escaped) = self.base_encode(getattr(pair, 'key'), escaped)
+                    setattr(pair, 'key', key)
+
                 setattr(value, 'str', escaped)
             else:
                 setattr(value, 'str', str(dictionary[key]))

--- a/pyresponse.py
+++ b/pyresponse.py
@@ -10,7 +10,7 @@ from suds.client import Client as Suds
 import types
 
 class PureResponseClient(object):
-    version = '1.2.3'
+    version = '1.2.4'
 
     api_client = None
     api_account_level = None
@@ -18,18 +18,18 @@ class PureResponseClient(object):
     api_core = None
     api_translator = None
 
-    unicode_exceptions = [Core.Entity.ID, Core.Message.ID, Core.List.ID]
-
-    class Api:
-        RPC_LITERAL_BRANDED = 'http://paint.pure360.com/paint.pure360.com/ctrlPaintLiteral.wsdl'
-        RPC_LITERAL_UNBRANDED = 'http://emailapi.co.uk/emailapi.co.uk/ctrlPaintLiteral.wsdl'
+    encoding_exceptions = [Core.Entity.ID,
+                           Core.Message.ID,
+                           Core.List.ID,
+                           Core.Api.USERNAME,
+                           Core.Api.PASSWORD]
 
     class AccountLevel:
         LITE = 10
         PRO = 20
         EXPERT = 40
 
-    def __init__(self, api_version=Api.RPC_LITERAL_UNBRANDED):
+    def __init__(self, api_version=Core.Api.RPC_LITERAL_UNBRANDED):
         self.api_client = Suds(api_version)
         self.api_translator = Translator(self)
         self.api_core = Core(self)

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,3 @@
 from distutils.core import setup
 
-setup(name='pyresponse', version='1.2.3', py_modules=['pyresponse'], requires=['suds'])
+setup(name='pyresponse', version='1.2.4', py_modules=['pyresponse'], requires=['suds'])


### PR DESCRIPTION
Moved the Api class to Core, added username/password and also added these to unicode exceptions which has been renamed encoding_exceptions - thus avoding an error where unicode strings are used for credentials, causing the credentials to be base encoded - something pure does not care for. Re-used base_encode for dryness. version 1.2.3 --> 1.2.4
